### PR TITLE
Add random agents management

### DIFF
--- a/examples/slow_charge_rb.cpp
+++ b/examples/slow_charge_rb.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
   std::cout << "Number of exits: " << n << '\n';
 
   dynamics.setErrorProbability(0.05);
-  dynamics.setMaxFlowPercentage(0.7707);
+  dynamics.setPassageProbability(0.7707);
   // dynamics.setForcePriorities(true);
   dynamics.setSpeedFluctuationSTD(0.1);
 

--- a/examples/stalingrado.cpp
+++ b/examples/stalingrado.cpp
@@ -51,7 +51,7 @@ int main() {
   Street s01{1, 2281 / 8, 2281., 13.9, std::make_pair(0, 1)};
   Street s12{7, 118 / 8, 118., 13.9, std::make_pair(1, 2)};
   Street s23{13, 222 / 8, 222., 13.9, std::make_pair(2, 3)};
-  Street s34{19, 651 / 4, 651., 13.9, std::make_pair(3, 4)};
+  Street s34{19, 1, 651., 13.9, std::make_pair(3, 4), 2};
   // Viale Aldo Moro
   TrafficLight tl1{1, 132};
   tl1.setCycle(s01.id(), dsm::Direction::ANY, {62, 0});
@@ -76,6 +76,8 @@ int main() {
   graph.addNode(std::make_unique<TrafficLight>(tl4));
   graph.addStreets(s01, s12, s23, s34);
   graph.buildAdj();
+  graph.adjustNodeCapacities();
+  graph.normalizeStreetCapacities();
   auto& spire = graph.makeSpireStreet(19);
 
   std::cout << "Intersections: " << graph.nNodes() << '\n';
@@ -84,7 +86,7 @@ int main() {
   // Create the dynamics
   Dynamics dynamics{graph, 69, 0.95};
   dynamics.setSpeedFluctuationSTD(0.2);
-  Itinerary itinerary{0, 4};
+  Itinerary itinerary{4, 4};
   dynamics.addItinerary(itinerary);
   dynamics.updatePaths();
 
@@ -108,7 +110,7 @@ int main() {
       if (progress % 300 == 0) {
         ofs << progress << ';' << spire.outputCounts(true) << std::endl;
       }
-      dynamics.addAgents(0, *it / 2, 0);
+      dynamics.addAgents(4, *it / 2, 0);
     }
     dynamics.evolve(false);
     ++progress;

--- a/src/dsm/dsm.hpp
+++ b/src/dsm/dsm.hpp
@@ -6,7 +6,7 @@
 
 static constexpr uint8_t DSM_VERSION_MAJOR = 2;
 static constexpr uint8_t DSM_VERSION_MINOR = 2;
-static constexpr uint8_t DSM_VERSION_PATCH = 5;
+static constexpr uint8_t DSM_VERSION_PATCH = 6;
 
 static auto const DSM_VERSION =
     std::format("{}.{}.{}", DSM_VERSION_MAJOR, DSM_VERSION_MINOR, DSM_VERSION_PATCH);

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -42,9 +42,11 @@ namespace dsm {
   public:
     /// @brief Construct a new Agent object
     /// @param id The agent's id
-    /// @param itineraryId The agent's itinerary
+    /// @param itineraryId Optional, The agent's destination node. If not provided, the agent is a random agent
     /// @param srcNodeId Optional, The id of the source node of the agent
-    Agent(Id id, Id itineraryId, std::optional<Id> srcNodeId = std::nullopt);
+    Agent(Id id,
+          std::optional<Id> itineraryId = std::nullopt,
+          std::optional<Id> srcNodeId = std::nullopt);
     /// @brief Construct a new Agent object
     /// @param id The agent's id
     /// @param itineraryIds The agent's itinerary
@@ -123,13 +125,17 @@ namespace dsm {
     /// @brief Get the agent's travel time
     /// @return The agent's travel time
     unsigned int time() const { return m_time; }
+    /// @brief Return true if the agent is a random agent
+    /// @return True if the agent is a random agent, false otherwise
+    bool isRandom() const { return m_trip.empty(); }
   };
 
   template <typename delay_t>
     requires(is_numeric_v<delay_t>)
-  Agent<delay_t>::Agent(Id id, Id itineraryId, std::optional<Id> srcNodeId)
+  Agent<delay_t>::Agent(Id id, std::optional<Id> itineraryId, std::optional<Id> srcNodeId)
       : m_id{id},
-        m_trip{itineraryId},
+        m_trip{itineraryId.has_value() ? std::vector<Id>{itineraryId.value()}
+                                       : std::vector<Id>{}},
         m_srcNodeId{srcNodeId},
         m_delay{0},
         m_speed{0.},

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -193,6 +193,8 @@ namespace dsm {
                            const TContainer& src_weights,
                            const TContainer& dst_weights);
 
+    void addRandomAgents(Size nAgents, std::optional<Id> srcNodeId = std::nullopt);
+
     /// @brief Remove an agent from the simulation
     /// @param agentId the id of the agent to remove
     void removeAgent(Size agentId);
@@ -553,6 +555,22 @@ namespace dsm {
       }
       this->addAgent(srcId, itineraryIt->first);
       --nAgents;
+    }
+  }
+
+  template <typename agent_t>
+  void Dynamics<agent_t>::addRandomAgents(Size nAgents, std::optional<Id> srcNodeId) {
+    if (m_agents.size() + nAgents > m_graph.maxCapacity()) {
+      throw std::overflow_error(buildLog(
+          std::format("Graph is already holding the max possible number of agents ({})",
+                      m_graph.maxCapacity())));
+    }
+    Id agentId{0};
+    if (!m_agents.empty()) {
+      agentId = m_agents.rbegin()->first + 1;
+    }
+    for (auto i{0}; i < nAgents; ++i) {
+      this->addAgent(agent_t{agentId, srcNodeId});
     }
   }
 

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -241,6 +241,9 @@ namespace dsm {
     /// @brief Get the agents
     /// @return const std::unordered_map<Id, Agent<Id>>&, The agents
     const std::map<Id, std::unique_ptr<agent_t>>& agents() const { return m_agents; }
+    /// @brief Get the number of agents currently in the simulation
+    /// @return Size The number of agents
+    const Size nAgents() const { return m_agents.size(); }
     /// @brief Get the time
     /// @return Time The time
     Time time() const { return m_time; }
@@ -569,7 +572,7 @@ namespace dsm {
     if (!m_agents.empty()) {
       agentId = m_agents.rbegin()->first + 1;
     }
-    for (auto i{0}; i < nAgents; ++i) {
+    for (auto i{0}; i < nAgents; ++i, ++agentId) {
       this->addAgent(agent_t{agentId, srcNodeId});
     }
   }
@@ -580,7 +583,6 @@ namespace dsm {
   }
 
   template <typename agent_t>
-
   template <typename T1, typename... Tn>
     requires(std::is_convertible_v<T1, Size> && (std::is_convertible_v<Tn, Size> && ...))
   void Dynamics<agent_t>::removeAgents(T1 id, Tn... ids) {

--- a/src/dsm/headers/Graph.cpp
+++ b/src/dsm/headers/Graph.cpp
@@ -143,7 +143,7 @@ namespace dsm {
     }
   }
 
-  void Graph::importMatrix(const std::string& fileName, bool isAdj) {
+  void Graph::importMatrix(const std::string& fileName, bool isAdj, double defaultSpeed) {
     // check the file extension
     std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
     if (fileExt == "dsm") {
@@ -178,6 +178,7 @@ namespace dsm {
         if (!isAdj) {
           m_streets[index]->setLength(val);
         }
+        m_streets[index]->setMaxSpeed(defaultSpeed);
       }
     } else {
       // default case: read the file as a matrix with the first two elements being the number of rows and columns and
@@ -223,6 +224,7 @@ namespace dsm {
           if (!isAdj) {
             m_streets[index]->setLength(value);
           }
+          m_streets[index]->setMaxSpeed(defaultSpeed);
         }
         ++index;
       }

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -121,9 +121,12 @@ namespace dsm {
     /// the number of rows and columns and the following elements being the matrix elements.
     /// @param fileName The name of the file to import the adjacency matrix from.
     /// @param isAdj A boolean value indicating if the file contains the adjacency matrix or the distance matrix.
+    /// @param defaultSpeed The default speed limit for the streets
     /// @throws std::invalid_argument if the file is not found or invalid
     /// The matrix format is deduced from the file extension. Currently only .dsm files are supported.
-    void importMatrix(const std::string& fileName, bool isAdj = true);
+    void importMatrix(const std::string& fileName,
+                      bool isAdj = true,
+                      double defaultSpeed = 13.8888888889);
     /// @brief Import the graph's nodes from a file
     /// @param fileName The name of the file to import the nodes from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported

--- a/src/dsm/headers/RoadDynamics.hpp
+++ b/src/dsm/headers/RoadDynamics.hpp
@@ -359,6 +359,8 @@ namespace dsm {
   template <typename delay_t>
     requires(is_numeric_v<delay_t>)
   void RoadDynamics<delay_t>::m_evolveAgents() {
+    std::uniform_int_distribution<Id> nodeDist{
+        0, static_cast<Id>(this->m_graph.nNodes() - 1)};
     for (const auto& [agentId, agent] : this->m_agents) {
       if (agent->delay() > 0) {
         const auto& street{this->m_graph.streetSet()[agent->streetId().value()]};
@@ -418,8 +420,9 @@ namespace dsm {
         }
       } else if (!agent->streetId().has_value() &&
                  !m_agentNextStreetId.contains(agentId)) {
-        assert(agent->srcNodeId().has_value());
-        const auto& srcNode{this->m_graph.nodeSet()[agent->srcNodeId().value()]};
+        Id srcNodeId = agent->srcNodeId().has_value() ? agent->srcNodeId().value()
+                                                      : nodeDist(this->m_generator);
+        const auto& srcNode{this->m_graph.nodeSet()[srcNodeId]};
         if (srcNode->isFull()) {
           continue;
         }

--- a/test/Test_agent.cpp
+++ b/test/Test_agent.cpp
@@ -44,5 +44,12 @@ TEST_CASE("Agent") {
         }
       }
     }
+    GIVEN("An agent it") {
+      uint16_t agentId{1};
+      WHEN("The agent is constructed") {
+        auto randomAgent = Agent{agentId};
+        THEN("The agent is a random agent") { CHECK(randomAgent.isRandom()); }
+      }
+    }
   }
 }

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Dynamics") {
       WHEN("We add the agent") {
         dynamics.addAgent(0, 2);
         THEN("The agent is added") {
-          CHECK_EQ(dynamics.agents().size(), 1);
+          CHECK_EQ(dynamics.nAgents(), 1);
           const auto& agent = dynamics.agents().at(0);
           CHECK_EQ(agent->id(), 0);
           CHECK_EQ(agent->srcNodeId().value(), 0);
@@ -163,7 +163,7 @@ TEST_CASE("Dynamics") {
         THEN(
             "The number of agents is 1 and the destination is the same as the "
             "itinerary") {
-          CHECK_EQ(dynamics.agents().size(), 1);
+          CHECK_EQ(dynamics.nAgents(), 1);
           CHECK_EQ(dynamics.itineraries()
                        .at(dynamics.agents().at(0)->itineraryId())
                        ->destination(),
@@ -184,7 +184,7 @@ TEST_CASE("Dynamics") {
             "The number of agents is 3, the destination and the street is the "
             "same as "
             "the itinerary") {
-          CHECK_EQ(dynamics.agents().size(), 3);
+          CHECK_EQ(dynamics.nAgents(), 3);
           CHECK(dynamics.agents().at(0)->streetId().has_value());
           CHECK(dynamics.agents().at(1)->streetId().has_value());
           CHECK(dynamics.agents().at(2)->streetId().has_value());
@@ -236,7 +236,7 @@ TEST_CASE("Dynamics") {
         dynamics.addItinerary(Itinerary{0, 2});
         dynamics.addAgentsRandomly(1, src, dst);
         THEN("The agents are correctly set") {
-          CHECK_EQ(dynamics.agents().size(), 1);
+          CHECK_EQ(dynamics.nAgents(), 1);
           CHECK_EQ(dynamics.itineraries()
                        .at(dynamics.agents().at(0)->itineraryId())
                        ->destination(),
@@ -252,7 +252,7 @@ TEST_CASE("Dynamics") {
         dynamics.addItinerary(Itinerary{2, 107});
         dynamics.addAgentsRandomly(3, src, dst);
         THEN("The agents are correctly set") {
-          CHECK_EQ(dynamics.agents().size(), 3);
+          CHECK_EQ(dynamics.nAgents(), 3);
           CHECK_EQ(dynamics.itineraries()
                        .at(dynamics.agents().at(0)->itineraryId())
                        ->destination(),
@@ -279,6 +279,28 @@ TEST_CASE("Dynamics") {
       }
     }
   }
+  SUBCASE("addRandomAgents") {
+    GIVEN("A dynamics object") {
+      auto const p{0.1};
+      auto const n{100};
+      auto graph = Graph{};
+      graph.importMatrix("./data/matrix.dat", false);
+      graph.buildAdj();
+      graph.normalizeStreetCapacities();
+      Dynamics dynamics{graph, 69};
+      dynamics.setPassageProbability(p);
+      WHEN("We add some agent") {
+        dynamics.addRandomAgents(n);
+        THEN("The number of agents is correct") { CHECK_EQ(dynamics.nAgents(), 100); }
+        THEN("If we evolve the dynamics agent disappear gradually") {
+          for (auto i{0}; i < 40; ++i) {
+            dynamics.evolve(false);
+          }
+          CHECK(dynamics.nAgents() < n);
+        }
+      }
+    }
+  }
   SUBCASE("addAgents") {
     GIVEN("A dynamics object and one itinerary") {
       auto graph = Graph{};
@@ -296,7 +318,7 @@ TEST_CASE("Dynamics") {
         THEN(
             "The number of agents is 1 and the destination is the same as the "
             "itinerary") {
-          CHECK_EQ(dynamics.agents().size(), 1);
+          CHECK_EQ(dynamics.nAgents(), 1);
           CHECK_EQ(dynamics.itineraries()
                        .at(dynamics.agents().at(0)->itineraryId())
                        ->destination(),
@@ -305,7 +327,7 @@ TEST_CASE("Dynamics") {
       }
       WHEN("We add 69 agents with itinerary 0") {
         dynamics.addAgents(0, 69);
-        THEN("The number of agents is 69") { CHECK_EQ(dynamics.agents().size(), 69); }
+        THEN("The number of agents is 69") { CHECK_EQ(dynamics.nAgents(), 69); }
       }
     }
   }
@@ -524,7 +546,7 @@ TEST_CASE("Dynamics") {
         }
         dynamics.evolve(true);
         THEN("The agent is reinserted") {
-          CHECK_EQ(dynamics.agents().size(), 1);
+          CHECK_EQ(dynamics.nAgents(), 1);
           CHECK_EQ(dynamics.agents().at(0)->time(), 1);
           CHECK_EQ(dynamics.agents().at(0)->delay(), 0);
           CHECK_FALSE(dynamics.agents().at(0)->streetId().has_value());


### PR DESCRIPTION
- (Finally) close #107

Random agents are immortal agents. The only way to kill them is to set the passage probability at junctions: if a normal agent cannot pass, it waits, but if a random agent cannot pass, it dies.